### PR TITLE
Add tests for game and CLI logic

### DIFF
--- a/tests/test_cli_module.py
+++ b/tests/test_cli_module.py
@@ -1,0 +1,67 @@
+import builtins
+from typing import List
+
+from src import cli
+
+
+def _make_dummy_manager():
+    class DummyManager:
+        instances: List["DummyManager"] = []
+
+        def __init__(self):
+            self.saved: List[int] = []
+            self.high_score = 0
+            DummyManager.instances.append(self)
+
+        def load(self) -> None:
+            pass
+
+        def save_score(self, score: int) -> bool:
+            self.saved.append(score)
+            if score > self.high_score:
+                self.high_score = score
+            return True
+
+    return DummyManager
+
+
+def test_cli_invalid_input(monkeypatch, capsys):
+    Dummy = _make_dummy_manager()
+    # save_score should indicate not a new high score to exercise the other branch
+    def save_score(self, score: int) -> bool:
+        self.saved.append(score)
+        if score > self.high_score:
+            self.high_score = score
+        return False
+    Dummy.save_score = save_score  # type: ignore
+
+    monkeypatch.setattr(cli, "ScoreManager", Dummy)
+    monkeypatch.setattr(cli, "generate_next_note", lambda diff: 1)
+    monkeypatch.setattr(cli, "play_sequence", lambda seq, use_audio=False: None)
+
+    inputs = iter(["not numbers", "n"])
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs))
+
+    cli.main(["--levels", "2"])
+    out = capsys.readouterr().out
+    assert "Invalid input, numbers only. Game over." in out
+    assert Dummy.instances[0].saved == [0]
+
+
+def test_cli_level_progress_and_score_update(monkeypatch, capsys):
+    Dummy = _make_dummy_manager()
+    monkeypatch.setattr(cli, "ScoreManager", Dummy)
+
+    notes = iter([1, 2])
+    monkeypatch.setattr(cli, "generate_next_note", lambda diff: next(notes))
+    monkeypatch.setattr(cli, "play_sequence", lambda seq, use_audio=False: None)
+
+    inputs = iter(["1", "1 2", "n"])
+    monkeypatch.setattr(builtins, "input", lambda _: next(inputs))
+
+    cli.main(["--levels", "2"])
+    out = capsys.readouterr().out
+    assert "Level 2. Listen to the sequence:" in out
+    assert "Congratulations! You completed all levels." in out
+    assert "New high score: 2!" in out
+    assert Dummy.instances[0].saved == [2]

--- a/tests/test_game_module.py
+++ b/tests/test_game_module.py
@@ -1,0 +1,35 @@
+import pytest
+from src import game
+
+
+def test_generate_sequence_negative_length():
+    with pytest.raises(ValueError):
+        game.generate_sequence(-1)
+
+
+def test_generate_level_sequence_length_increments(monkeypatch):
+    monkeypatch.setattr(game.random, "choice", lambda seq: seq[0])
+    seq1 = game.generate_level_sequence(1, base_length=2, step=2, notes=[1])
+    seq3 = game.generate_level_sequence(3, base_length=2, step=2, notes=[1])
+    assert len(seq1) == 2
+    assert len(seq3) == 6  # 2 + (3-1)*2
+
+
+def test_play_sequence_uses_mocked_audio(monkeypatch):
+    calls = []
+
+    def fake_play(freq):
+        calls.append(freq)
+
+    monkeypatch.setattr(game, "_play_tone", fake_play)
+    # avoid actual sleeping if fallback is used
+    monkeypatch.setattr(game.time, "sleep", lambda *_: None)
+    sequence = [1, 2]
+    game.play_sequence(sequence, use_audio=True, delay=0)
+    expected = [game._freq_of(1), game._freq_of(2)]
+    assert calls == expected
+
+
+def test_check_sequence():
+    assert game.check_sequence([1, 2], [1, 2])
+    assert not game.check_sequence([1, 2], [2, 1])


### PR DESCRIPTION
## Summary
- test game sequence generation, level length increments, and audio playback using mocks
- test CLI flow including invalid input, level progression, and score updates while mocking audio

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace3d294708327b2555fd6ab678be6