### PR TITLE
feat: add multi-mode interface

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 simpleaudio
+colorama

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,15 +1,33 @@
 import argparse
+import sys
+from pathlib import Path
 from typing import List
 
 from .score import ScoreManager
 
-# Support running as module or script
+# Optional colour support ----------------------------------------------------
+try:  # pragma: no cover - optional dependency
+    from colorama import Fore, Style, init as colorama_init
+
+    colorama_init()
+
+    def _colour(text: str, colour: str) -> str:
+        return f"{colour}{text}{Style.RESET_ALL}" if sys.stdout.isatty() else text
+
+except Exception:  # pragma: no cover - colour is optional
+    class _DummyFore:
+        CYAN = YELLOW = RED = GREEN = MAGENTA = ""
+
+    Fore = _DummyFore()  # type: ignore
+
+    def _colour(text: str, colour: str) -> str:
+        return text
+
+
+# Support running as module or script ----------------------------------------
 try:  # pragma: no cover - import resolution
     from .game import generate_next_note, play_sequence, check_sequence
 except ImportError:  # pragma: no cover
-    from pathlib import Path
-    import sys
-
     sys.path.append(str(Path(__file__).resolve().parent))
     from game import generate_next_note, play_sequence, check_sequence
 
@@ -28,12 +46,17 @@ def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="play tones using simpleaudio if available",
     )
+    parser.add_argument(
+        "--mode",
+        choices=["cli", "gui", "web"],
+        default="cli",
+        help="choose interaction mode",
+    )
     return parser.parse_args(argv)
 
 
-def main(argv: List[str] | None = None) -> None:
-    args = parse_args(argv)
-    print("Welcome to Musical Memory!")
+def _run_cli(args: argparse.Namespace) -> None:
+    print(_colour("Welcome to Musical Memory!", Fore.CYAN))
 
     manager = ScoreManager()
     manager.load()
@@ -43,34 +66,87 @@ def main(argv: List[str] | None = None) -> None:
         score = 0
         for level in range(1, args.levels + 1):
             sequence.append(generate_next_note(args.difficulty))
-            print(f"Level {level}. Listen to the sequence:")
+            print(_colour(f"Level {level}. Listen to the sequence:", Fore.YELLOW))
             play_sequence(sequence, use_audio=args.audio)
             guess = input("Repeat the sequence separated by spaces: ").strip()
             try:
                 user_sequence = [int(x) for x in guess.split()]
             except ValueError:
-                print("Invalid input, numbers only. Game over.")
+                print(
+                    _colour(
+                        f"Invalid input, numbers only. Game over. Provided: {guess}",
+                        Fore.RED,
+                    )
+                )
                 break
             if check_sequence(sequence, user_sequence):
-                print("Correct!\n")
+                print(_colour("Correct!\n", Fore.GREEN))
                 score = level
             else:
-                print("Wrong sequence. Game over.")
+                print(
+                    _colour(
+                        f"Wrong sequence. Game over. Expected {' '.join(map(str, sequence))}",
+                        Fore.RED,
+                    )
+                )
                 break
         else:
-            print("Congratulations! You completed all levels.")
+            print(_colour("Congratulations! You completed all levels.", Fore.CYAN))
             score = args.levels
 
         is_high = manager.save_score(score)
         if is_high:
-            print(f"New high score: {manager.high_score}!")
+            print(_colour(f"New high score: {manager.high_score}!", Fore.MAGENTA))
         else:
-            print(f"Your score: {score}. High score: {manager.high_score}.")
+            print(
+                _colour(
+                    f"Your score: {score}. High score: {manager.high_score}.", Fore.MAGENTA
+                )
+            )
 
         again = input("Play again? (y/n): ").strip().lower()
         if again != "y":
-            print("Thanks for playing!")
+            print(_colour("Thanks for playing!", Fore.CYAN))
             break
+
+
+def _run_gui(args: argparse.Namespace) -> None:  # pragma: no cover - manual mode
+    import tkinter as tk
+
+    root = tk.Tk()
+    root.title("Musical Memory")
+    tk.Label(root, text="GUI mode is under construction").pack(padx=20, pady=20)
+    root.mainloop()
+
+
+def _run_web(args: argparse.Namespace) -> None:  # pragma: no cover - manual mode
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: D401 - small handler
+            self.send_response(200)
+            self.send_header("Content-type", "text/html")
+            self.end_headers()
+            self.wfile.write(
+                b"<html><body><h1>Musical Memory web mode is under construction</h1></body></html>"
+            )
+
+    server = HTTPServer(("127.0.0.1", 8000), Handler)
+    print("Serving on http://127.0.0.1:8000 - press Ctrl+C to stop")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+def main(argv: List[str] | None = None) -> None:
+    args = parse_args(argv)
+    if args.mode == "cli":
+        _run_cli(args)
+    elif args.mode == "gui":
+        _run_gui(args)
+    else:
+        _run_web(args)
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -35,6 +35,8 @@ def _load_config(path: str) -> List[str]:
         args.extend(["--difficulty", data["difficulty"]])
     if data.get("audio"):
         args.append("--audio")
+    if "mode" in data:
+        args.extend(["--mode", data["mode"]])
     return args
 
 


### PR DESCRIPTION
## Summary
- add optional colorized output and detailed error prompts
- introduce GUI and web stubs with selectable interaction modes
- allow selecting mode from JSON config and add colorama dependency

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement simpleaudio)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ace4ba86a08327bec6a84eeeeae4c5