### PR TITLE
Add docstrings and developer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
 # Musical Memory
 
-## 游戏目标
-记住并重复播放的一系列音调，考验记忆力与节奏感。
-
-## 运行方式
-1. 安装依赖：`pip install -r requirements.txt`
-2. 运行游戏：`python src/main.py`
-
-## 依赖
-- Python 3.11+
-- simpleaudio
-
-A minimal project placeholder.
+Musical Memory 是一个简单的记忆游戏：玩家需要记住并重复播放的音符序列。
 
 ## Installation
 
@@ -23,10 +12,25 @@ pip install -r requirements.txt
 
 ## Running
 
-After installing dependencies, run the project:
+运行入口位于 `src.main`，建议使用模块方式启动：
 
 ```bash
-python main.py
+python -m src.main --levels 5 --difficulty easy
 ```
- 
-The `main.py` entry point is a placeholder for future implementation. 
+
+常用参数：
+
+- `--levels`：关卡数量（默认 `5`）
+- `--difficulty`：难度 `easy|medium|hard`
+- `--audio`：若系统支持，将播放真实音调
+- `--mode`：交互模式 `cli|gui|web`
+- `--config`：可选的 JSON 配置文件
+
+## Extending
+
+- 在 `src/game.py` 中修改 `DIFFICULTY_NOTES` 或 `NOTES` 以定制音符池。
+- 在 `src/cli.py` 中完善 `_run_gui` 或 `_run_web`，或添加新的模式以扩展交互方式。
+- 通过扩展 `src/score.py` 中的 `ScoreManager`，可替换或接入不同的分数存储方案。
+
+更多开发信息请参阅 [`docs/developer-guide.md`](docs/developer-guide.md)。
+

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -1,0 +1,41 @@
+# Developer Guide
+
+This document provides a quick overview for contributors.
+
+## Environment Setup
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Running Checks
+
+Run the test suite with:
+
+```bash
+pytest
+```
+
+The repository uses *pre-commit* for formatting and linting. After making
+changes run it on the touched files:
+
+```bash
+pre-commit run --files <file1> <file2>
+```
+
+## Project Structure
+
+- `src/cli.py` – command line interface and experimental GUI/web modes.
+- `src/game.py` – game logic and sequence generation utilities.
+- `src/score.py` – score storage abstraction.
+- `src/main.py` – entrypoint that parses configuration then delegates to the CLI.
+- `musical_memory/core.py` – stand‑alone class for managing note sequences.
+
+## Extending the Game
+
+- Add new interaction modes by expanding functions in `src/cli.py`.
+- Introduce alternative note pools or difficulty rules in `src/game.py`.
+- Replace the `ScoreManager` in `src/score.py` to store scores elsewhere.
+

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,3 +1,9 @@
+"""Command-line interface for the Musical Memory game.
+
+This module provides a CLI for playing the game, as well as experimental
+GUI and web modes that can be expanded in the future.
+"""
+
 import argparse
 import sys
 from pathlib import Path
@@ -33,6 +39,14 @@ except ImportError:  # pragma: no cover
 
 
 def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    """Parse command-line options for the game.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of argument strings. When ``None`` the arguments are
+        taken from :data:`sys.argv`.
+    """
     parser = argparse.ArgumentParser(description="Musical memory game")
     parser.add_argument("--levels", type=int, default=5, help="number of levels to play")
     parser.add_argument(
@@ -56,6 +70,8 @@ def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
 
 
 def _run_cli(args: argparse.Namespace) -> None:
+    """Run the interactive command-line version of the game."""
+
     print(_colour("Welcome to Musical Memory!", Fore.CYAN))
 
     manager = ScoreManager()
@@ -111,6 +127,8 @@ def _run_cli(args: argparse.Namespace) -> None:
 
 
 def _run_gui(args: argparse.Namespace) -> None:  # pragma: no cover - manual mode
+    """Run a very small experimental Tk GUI."""
+
     import tkinter as tk
 
     root = tk.Tk()
@@ -120,6 +138,8 @@ def _run_gui(args: argparse.Namespace) -> None:  # pragma: no cover - manual mod
 
 
 def _run_web(args: argparse.Namespace) -> None:  # pragma: no cover - manual mode
+    """Start a minimal HTTP server announcing the web mode."""
+
     from http.server import BaseHTTPRequestHandler, HTTPServer
 
     class Handler(BaseHTTPRequestHandler):
@@ -140,6 +160,8 @@ def _run_web(args: argparse.Namespace) -> None:  # pragma: no cover - manual mod
 
 
 def main(argv: List[str] | None = None) -> None:
+    """Entry point choosing between CLI, GUI and web modes."""
+
     args = parse_args(argv)
     if args.mode == "cli":
         _run_cli(args)


### PR DESCRIPTION
## Summary
- document CLI module and helper functions with clear docstrings
- expand README with run instructions and extension ideas
- add developer guide for environment setup and project structure

## Testing
- `pytest`
- `pre-commit run --files README.md src/cli.py docs/developer-guide.md` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace6e92e5c8327a60909c27a7d153d