### PR TITLE
Add profile system and configurable difficulty

### DIFF
--- a/src/profile.py
+++ b/src/profile.py
@@ -1,0 +1,117 @@
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Any, Tuple
+
+
+@dataclass
+class UserProfile:
+    """A single player's stored progress and settings."""
+
+    name: str
+    high_score: int = 0
+    history: List[int] = field(default_factory=list)
+    settings: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ProfileManager:
+    """Manage multiple :class:`UserProfile` instances."""
+
+    file_path: Path = field(
+        default_factory=lambda: Path(__file__).with_name("profiles.json")
+    )
+    profiles: Dict[str, UserProfile] = field(default_factory=dict)
+
+    # -- Basic persistence -------------------------------------------------
+    def load(self) -> None:
+        """Load profile data from :attr:`file_path`."""
+        if self.file_path.exists():
+            with self.file_path.open("r", encoding="utf-8") as fh:
+                data = json.load(fh)
+            self.profiles = {
+                name: UserProfile(
+                    name=name,
+                    high_score=info.get("high_score", 0),
+                    history=info.get("history", []),
+                    settings=info.get("settings", {}),
+                )
+                for name, info in data.get("profiles", {}).items()
+            }
+        else:
+            self.profiles = {}
+
+    def save(self) -> None:
+        """Persist current profiles to :attr:`file_path`."""
+        data = {
+            "profiles": {
+                name: {
+                    "high_score": p.high_score,
+                    "history": p.history,
+                    "settings": p.settings,
+                }
+                for name, p in self.profiles.items()
+            }
+        }
+        with self.file_path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    # -- Profile operations -----------------------------------------------
+    def get_profile(self, name: str) -> UserProfile:
+        """Return existing profile or create a new one."""
+        profile = self.profiles.get(name)
+        if profile is None:
+            profile = UserProfile(name)
+            self.profiles[name] = profile
+        return profile
+
+    def record_score(self, name: str, score: int) -> bool:
+        """Record ``score`` for ``name`` and update high score.
+
+        Returns ``True`` if ``score`` is a new high score for the player.
+        """
+        profile = self.get_profile(name)
+        profile.history.append(score)
+        new_high = False
+        if score > profile.high_score:
+            profile.high_score = score
+            new_high = True
+        self.save()
+        return new_high
+
+    def leaderboard(self) -> List[Tuple[str, int]]:
+        """Return leaderboard as list of ``(name, high_score)`` tuples."""
+        return sorted(
+            ((p.name, p.high_score) for p in self.profiles.values()),
+            key=lambda item: item[1],
+            reverse=True,
+        )
+
+    # -- Import / Export ---------------------------------------------------
+    def export_data(self, path: Path) -> None:
+        """Export all profile data to ``path``."""
+        data = {
+            "profiles": {
+                name: {
+                    "high_score": p.high_score,
+                    "history": p.history,
+                    "settings": p.settings,
+                }
+                for name, p in self.profiles.items()
+            }
+        }
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    def import_data(self, path: Path) -> None:
+        """Import profile data from ``path`` and merge with existing data."""
+        if not path.exists():
+            return
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        for name, info in data.get("profiles", {}).items():
+            profile = self.get_profile(name)
+            profile.high_score = max(profile.high_score, info.get("high_score", 0))
+            profile.history.extend(info.get("history", []))
+            profile.settings.update(info.get("settings", {}))
+        self.save()

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+from pathlib import Path
+from src.profile import ProfileManager
+
+
+def test_profile_record_and_leaderboard(tmp_path: Path) -> None:
+    path = tmp_path / "profiles.json"
+    manager = ProfileManager(path)
+    manager.load()
+    manager.record_score("alice", 5)
+    manager.record_score("bob", 7)
+    lb = manager.leaderboard()
+    assert lb[0] == ("bob", 7)
+    assert lb[1] == ("alice", 5)
+
+
+def test_profile_export_import(tmp_path: Path) -> None:
+    path = tmp_path / "profiles.json"
+    manager = ProfileManager(path)
+    manager.load()
+    manager.record_score("alice", 10)
+    export_path = tmp_path / "export.json"
+    manager.export_data(export_path)
+
+    manager2 = ProfileManager(tmp_path / "other.json")
+    manager2.load()
+    manager2.import_data(export_path)
+    assert manager2.leaderboard() == [("alice", 10)]


### PR DESCRIPTION
## Summary
- add tempo and sequence step options to CLI
- introduce profile manager with import/export of scores and settings
- track user progress and show leaderboard in CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ace84ff0bc8327bcd74d4a55bbb59b