### PR TITLE
Add profile reset helper

### DIFF
--- a/src/profile.py
+++ b/src/profile.py
@@ -79,6 +79,19 @@ class ProfileManager:
         self.save()
         return new_high
 
+    def reset_profile(self, name: str) -> bool:
+        """Reset ``name`` back to an empty profile.
+
+        Returns ``True`` if a profile existed and was reset. Missing profiles
+        are left untouched and return ``False`` so callers can differentiate
+        between "reset" and "nothing to do" states.
+        """
+        if name not in self.profiles:
+            return False
+        self.profiles[name] = UserProfile(name)
+        self.save()
+        return True
+
     def leaderboard(self) -> List[Tuple[str, int]]:
         """Return leaderboard as list of ``(name, high_score)`` tuples."""
         return sorted(

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from pathlib import Path
+
 from src.profile import ProfileManager
 
 
@@ -26,3 +26,24 @@ def test_profile_export_import(tmp_path: Path) -> None:
     manager2.load()
     manager2.import_data(export_path)
     assert manager2.leaderboard() == [("alice", 10)]
+
+
+def test_reset_profile(tmp_path: Path) -> None:
+    path = tmp_path / "profiles.json"
+    manager = ProfileManager(path)
+    manager.load()
+    manager.record_score("alice", 8)
+    profile = manager.get_profile("alice")
+    profile.settings["difficulty"] = "hard"
+    manager.save()
+
+    assert manager.reset_profile("alice") is True
+    reset_profile = manager.get_profile("alice")
+    assert reset_profile.high_score == 0
+    assert reset_profile.history == []
+    assert reset_profile.settings == {}
+
+    # Ensure reset is persisted and missing profiles are not created
+    manager.load()
+    assert manager.get_profile("alice").high_score == 0
+    assert manager.reset_profile("bob") is False


### PR DESCRIPTION
## Summary
- add a reset_profile helper to ProfileManager for clearing a user's progress
- ensure reset behaviour is persisted and keep profile tests tidy

## Testing
- pytest tests/test_profile.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69483204d6c483279e212a5a445a1cc5)